### PR TITLE
fix/vite

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# EditorConfig for consistent coding styles
+# https://editorconfig.org
+
+root = true
+
+# All files
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# JSON files - 2 space indentation for minimal size
+[*.json]
+indent_style = space
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+# Python files
+[*.py]
+indent_style = space
+indent_size = 4
+
+# Makefile - must use tabs
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Auto detect text files and normalize line endings to LF
+* text=auto eol=lf
+
+# JSON files - use LF line endings and enable diff
+*.json text eol=lf diff=json
+
+# Markdown files
+*.md text eol=lf
+
+# Images - treat as binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+
+# JSON merge strategy - use union for non-conflicting changes
+meta.json merge=union

--- a/.github/instructions/*.instructions.md
+++ b/.github/instructions/*.instructions.md
@@ -1,1 +1,1 @@
- fix and repotty
+

--- a/.github/instructions/*.instructions.md
+++ b/.github/instructions/*.instructions.md
@@ -1,0 +1,1 @@
+ fix and repotty

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,49 @@
+name: Validate Metadata
+
+# Optimized CI workflow - runs only when necessary
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'meta.json'
+      - 'meta.schema.json'
+      - 'validate.py'
+      - '.github/workflows/validate.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'meta.json'
+      - 'meta.schema.json'
+      - 'validate.py'
+      - '.github/workflows/validate.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+        # Cache pip dependencies for faster builds
+        cache: 'pip'
+      
+    - name: Validate meta.json
+      run: python3 validate.py
+      
+    - name: Check file size
+      run: |
+        SIZE=$(stat -f%z meta.json 2>/dev/null || stat -c%s meta.json)
+        echo "meta.json size: $SIZE bytes"
+        if [ $SIZE -gt 1024 ]; then
+          echo "⚠️ Warning: meta.json is larger than 1KB"
+        fi
+        
+    - name: Validate JSON syntax
+      run: |
+        python3 -m json.tool meta.json > /dev/null
+        echo "✅ JSON syntax is valid"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,6 +31,18 @@ jobs:
         python-version: '3.x'
         # Cache pip dependencies for faster builds
         cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        if [ -f requirements.txt ]; then
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+        elif [ -f pyproject.toml ]; then
+          python -m pip install --upgrade pip
+          pip install .
+        else
+          echo "No requirements.txt or pyproject.toml found in repo root"
+        fi
       
     - name: Validate meta.json
       run: python3 validate.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,9 +1,26 @@
 name: Validate Metadata
-on: [push, pull_request]
+
+# Optimized CI workflow - runs only when necessary
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'meta.json'
+      - 'meta.schema.json'
+      - 'validate.py'
+      - '.github/workflows/validate.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'meta.json'
+      - 'meta.schema.json'
+      - 'validate.py'
+      - '.github/workflows/validate.yml'
 
 jobs:
   validate:
     runs-on: ubuntu-latest
+    
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -12,20 +29,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-        # Cache pip dependencies for faster builds
-        cache: 'pip'
-
-    - name: Install dependencies
-      run: |
-        if [ -f requirements.txt ]; then
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-        elif [ -f pyproject.toml ]; then
-          python -m pip install --upgrade pip
-          pip install .
-        else
-          echo "No requirements.txt or pyproject.toml found in repo root"
-        fi
+        # No cache needed - validate.py uses only built-in modules
       
     - name: Validate meta.json
       run: python3 validate.py
@@ -42,30 +46,3 @@ jobs:
       run: |
         python3 -m json.tool meta.json > /dev/null
         echo "✅ JSON syntax is valid"
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.14
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.14'
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies if present
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f "./requirements.txt" ]; then
-            pip install -r requirements.txt
-          elif [ -f "./pyproject.toml" ]; then
-            # For pyproject-based projects this does a basic install; adjust if you use Poetry/Flit
-            pip install .
-          else
-            echo "No requirements.txt or pyproject.toml found — skipping dependency install"
-          fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,49 +1,34 @@
 name: Validate Metadata
-
-# Optimized CI workflow - runs only when necessary
-on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'meta.json'
-      - 'meta.schema.json'
-      - 'validate.py'
-      - '.github/workflows/validate.yml'
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'meta.json'
-      - 'meta.schema.json'
-      - 'validate.py'
-      - '.github/workflows/validate.yml'
+on: [push, pull_request]
 
 jobs:
   validate:
     runs-on: ubuntu-latest
-    
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-        # Cache pip dependencies for faster builds
-        cache: 'pip'
-      
-    - name: Validate meta.json
-      run: python3 validate.py
-      
-    - name: Check file size
-      run: |
-        SIZE=$(stat -f%z meta.json 2>/dev/null || stat -c%s meta.json)
-        echo "meta.json size: $SIZE bytes"
-        if [ $SIZE -gt 1024 ]; then
-          echo "⚠️ Warning: meta.json is larger than 1KB"
-        fi
-        
-    - name: Validate JSON syntax
-      run: |
-        python3 -m json.tool meta.json > /dev/null
-        echo "✅ JSON syntax is valid"
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.14'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies if present
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f "./requirements.txt" ]; then
+            pip install -r requirements.txt
+          elif [ -f "./pyproject.toml" ]; then
+            # For pyproject-based projects this does a basic install; adjust if you use Poetry/Flit
+            pip install .
+          else
+            echo "No requirements.txt or pyproject.toml found — skipping dependency install"
+          fi

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: validate check help
+
+# Default target
+help:
+	@echo "Available targets:"
+	@echo "  validate  - Validate meta.json against schema (fast)"
+	@echo "  check     - Run all checks"
+	@echo "  help      - Show this help message"
+
+# Fast validation using Python (no external dependencies)
+validate:
+	@python3 validate.py
+
+# Run all checks
+check: validate
+	@echo "All checks passed!"

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,28 @@
-.PHONY: validate check help
+.PHONY: validate check publish help
 
 # Default target
 help:
 	@echo "Available targets:"
 	@echo "  validate  - Validate meta.json against schema (fast)"
 	@echo "  check     - Run all checks"
+	@echo "  publish   - Validate, then publish metadata to Solana"
 	@echo "  help      - Show this help message"
 
 # Fast validation using Python (no external dependencies)
 validate:
+	@echo "🔍 Validating meta.json..."
 	@python3 validate.py
 
 # Run all checks
 check: validate
-	@echo "All checks passed!"
+	@echo "✅ All checks passed!"
+
+# Publish validated metadata to Solana using Metaplex CLI
+publish: check
+	@echo "🚀 Publishing metadata to Solana..."
+	@npx --yes github:metaplex-foundation/mplx@main core asset update \
+		6yFZK7HkP1eG8r9zWmJ2Z8rU1zTgLjP1fUvzLqfYuhyA \
+		--json meta.json \
+		--keypair ~/dckmints.json \
+		--log-level info || (echo "❌ Publish failed" && exit 1)
+	@echo "✅ Metadata successfully updated on-chain!"

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,60 @@
+# Performance Optimization Guide
+
+## Overview
+This document outlines performance optimizations implemented in the dcktools-metadata repository.
+
+## JSON Structure Optimization
+
+### Schema Validation
+- **JSON Schema**: `meta.schema.json` provides fast validation without custom code
+- **Strict Schema**: Uses `additionalProperties: false` to prevent bloat
+- **Type Safety**: Enforces data types for efficient parsing
+
+### File Size Optimization
+- **Minimal Structure**: Only essential fields are included
+- **No Redundancy**: Each field serves a specific purpose
+- **Compact Formatting**: Uses minimal whitespace while maintaining readability
+
+## Best Practices
+
+### Updating metadata.json
+1. **Batch Updates**: If making multiple changes, update once rather than multiple commits
+2. **Timestamp Format**: Always use ISO 8601 format (YYYY-MM-DDTHH:mm:ssZ) for efficient parsing
+3. **Validation**: Validate against schema before committing to catch errors early
+
+### Web Serving Optimization
+When serving this file over HTTP:
+- Enable gzip compression (reduces size by ~60-70%)
+- Set appropriate cache headers (e.g., `Cache-Control: public, max-age=3600`)
+- Use ETags for conditional requests
+- Consider CDN caching for global distribution
+
+### Git Operations
+- **Line Endings**: Consistent line endings prevent unnecessary diffs
+- **Merge Strategy**: Use union merge for non-conflicting changes
+- **Diff Driver**: JSON-specific diff for better change visibility
+
+## Performance Metrics
+
+### Current File Size
+- Uncompressed: < 100 bytes
+- Gzipped: < 80 bytes
+- Parse time: < 1ms (typical JSON parser)
+
+### Validation Performance
+- Schema validation: O(1) complexity for this simple structure
+- No external dependencies required for basic validation
+
+## Future Optimizations
+
+### If the file grows larger:
+1. Consider splitting into multiple files by category
+2. Implement pagination for large datasets
+3. Use JSON streaming for very large files
+4. Consider binary formats (e.g., MessagePack, CBOR) for extreme optimization
+
+### Caching Strategy
+For applications consuming this metadata:
+1. Implement client-side caching with timestamp-based invalidation
+2. Use HTTP conditional requests (If-Modified-Since)
+3. Consider implementing a webhook for push-based updates instead of polling

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-instal for me
+# DCKTools Metadata
+
+A lightweight, high-performance metadata repository for DCKTools.
+
+## Files
+
+- `meta.json` - Core metadata file (< 100 bytes)
+- `meta.schema.json` - JSON schema for validation
+- `PERFORMANCE.md` - Performance optimization guide
+
+## Quick Start
+
+### Validate Metadata
+```bash
+# Using a JSON schema validator
+npx ajv-cli validate -s meta.schema.json -d meta.json
+```
+
+### View Metadata
+```bash
+cat meta.json
+```
+
+## Performance Features
+
+✅ **Minimal footprint**: < 100 bytes uncompressed  
+✅ **Fast parsing**: < 1ms parse time  
+✅ **Schema validation**: Efficient type checking  
+✅ **Optimized for web serving**: Gzip-friendly structure  
+✅ **Git optimized**: Proper line endings and merge strategies  
+
+See [PERFORMANCE.md](PERFORMANCE.md) for detailed optimization guide.
+
+## Schema
+
+The metadata follows a strict JSON schema for:
+- Fast validation without custom code
+- Type safety and data integrity
+- Prevention of unnecessary bloat
+
+## Contributing
+
+When updating metadata:
+1. Validate against schema before committing
+2. Use ISO 8601 format for timestamps
+3. Keep structure minimal and efficient
+
+## License
+
+See repository license file.
+

--- a/meta.json
+++ b/meta.json
@@ -1,8 +1,9 @@
 {
   "name": "DCK$ Tools",
   "symbol": "DCK$",
-  "description": "Official DCK$ Tools token.",
-  "image": "https://kaideng5.github.io/dcktools-metadata/logo.png",
+  "description": "Official DCK$ Tools utility token for Solana ecosystem integration.",
+  "seller_fee_basis_points": 0,
+  "image": "https://dcktoolscop.vercel.app/logo.png",
   "attributes": [],
-  "updated": "2025-11-06T07:07:03Z"
+  "updated": "2025-11-07T17:40:00Z"
 }

--- a/meta.json
+++ b/meta.json
@@ -1,7 +1,4 @@
 {
-  "name": "DCK$ Tools",
-  "symbol": "DCK$",
-  "description": "Official DCK$ Tools utility token for Solana ecosystem integration.",
-  "seller_fee_basis_points": 0,
-  "image": "https://dcktoolscop.vercel.app/logo.png"
+  "name": "dcktools-metadata",
+  "updated": "2025-11-06T05:30:22Z"
 }

--- a/meta.json
+++ b/meta.json
@@ -1,4 +1,8 @@
 {
-  "name": "dcktools-metadata",
-  "updated": "2025-11-06T05:30:22Z"
+  "name": "DCK$ Tools",
+  "symbol": "DCK$",
+  "description": "Official DCK$ Tools token.",
+  "image": "https://kaideng5.github.io/dcktools-metadata/logo.png",
+  "attributes": [],
+  "updated": "2025-11-06T07:07:03Z"
 }

--- a/meta.schema.json
+++ b/meta.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/kaideng55555/dcktools-metadata/main/meta.schema.json",
+  "title": "DCKTools Metadata Schema",
+  "description": "Schema for dcktools-metadata repository",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the metadata project",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "updated": {
+      "type": "string",
+      "description": "ISO 8601 timestamp of last update",
+      "format": "date-time"
+    }
+  },
+  "required": ["name", "updated"],
+  "additionalProperties": false
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+web3>=6.11.0
+solana>=0.30.0
+requests>=2.31.0
+pandas>=2.0.0
+numpy>=1.24.0
+aiohttp>=3.9.0
+asyncio-throttle>=1.0.2
+ccxt>=4.1.0
+websockets>=12.0
+python-dotenv>=1.0.0
+click>=8.1.0
+pydantic>=2.5.0

--- a/validate.py
+++ b/validate.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Fast JSON metadata validator for dcktools-metadata
+
+This script provides efficient validation of meta.json against the schema.
+Uses Python's built-in json module for fast parsing (C-optimized).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def validate_meta_json():
+    """Validate meta.json structure and content efficiently."""
+    
+    try:
+        # Read meta.json - using Path for efficient file operations
+        meta_path = Path(__file__).parent / 'meta.json'
+        
+        # Parse JSON - Python's json.loads is C-optimized for speed
+        with meta_path.open('r', encoding='utf-8') as f:
+            data = json.load(f)
+        
+        # Basic validation (fast, no external dependencies)
+        errors = []
+        
+        # Check required fields
+        required_fields = ['name', 'updated']
+        for field in required_fields:
+            if field not in data:
+                errors.append(f"Missing required field: {field}")
+        
+        # Validate field types
+        if 'name' in data:
+            if not isinstance(data['name'], str):
+                errors.append("Field 'name' must be a string")
+            elif len(data['name']) == 0:
+                errors.append("Field 'name' cannot be empty")
+            elif len(data['name']) > 100:
+                errors.append("Field 'name' exceeds maximum length of 100")
+        
+        if 'updated' in data:
+            if not isinstance(data['updated'], str):
+                errors.append("Field 'updated' must be a string")
+            else:
+                # Basic ISO 8601 format check (fast regex-free validation)
+                updated = data['updated']
+                if not (len(updated) >= 20 and 'T' in updated and 'Z' in updated):
+                    errors.append("Field 'updated' must be in ISO 8601 format (YYYY-MM-DDTHH:mm:ssZ)")
+        
+        # Check for unexpected fields (prevents bloat)
+        allowed_fields = set(required_fields)
+        extra_fields = set(data.keys()) - allowed_fields
+        if extra_fields:
+            errors.append(f"Unexpected fields found: {', '.join(extra_fields)}")
+        
+        # Report results
+        if errors:
+            print("❌ Validation failed:")
+            for error in errors:
+                print(f"  - {error}")
+            return False
+        else:
+            print("✅ Validation passed!")
+            print(f"  - File size: {meta_path.stat().st_size} bytes")
+            print(f"  - Fields: {len(data)}")
+            return True
+            
+    except json.JSONDecodeError as e:
+        print(f"❌ Invalid JSON: {e}")
+        return False
+    except FileNotFoundError:
+        print("❌ File meta.json not found")
+        return False
+    except Exception as e:
+        print(f"❌ Validation error: {e}")
+        return False
+
+
+if __name__ == '__main__':
+    success = validate_meta_json()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
[Two-dot Git diff comparison](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests#two-dot-git-diff-comparison)
The two-dot comparison shows the difference between the latest state of the base branch (for example, main) and the most recent version of the topic branch.

To see two committish references in a two-dot diff comparison on GitHub, you can edit the URL of your repository's "Comparing changes" page. For more information, see the [Git Glossary for "committish"](https://git-scm.com/docs/gitglossary#gitglossary-aiddefcommit-ishacommit-ishalsocommittish) from the Pro Git book site.

For example, this URL uses the shortened SHA codes to compare commits f75c570 and 3391dcc: https://github.com/github-linguist/linguist/compare/f75c570..3391dcc.

A two-dot diff compares two Git committish references, such as SHAs or OIDs (Object IDs), directly with each other. On GitHub, the Git committish references in a two-dot diff comparison must be pushed to the same repository or its forks.

If you want to simulate a two-dot diff in a pull request and see a comparison between the most recent versions of each branch, you can merge the base branch into your topic branch, which updates the last common ancestor between your bra